### PR TITLE
mod: 调整init.sh、添加docker-compose示例

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN /data/xcaddy/cmd/xcaddy/caddy -v
 
 FROM alpine:edge
 COPY --from=builder /data/xcaddy/cmd/xcaddy/caddy /usr/bin/
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache tzdata ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/cache/apk/*
 WORKDIR /data
 ENV TZ=Asia/Shanghai \
     DNS=""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  caddy:
+    image: public.ecr.aws/sliamb/caddy:latest
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - TZ=Asia/Shanghai
+    volumes:
+      - /usr/share/zoneinfo/Asia/Shanghai:/usr/share/zoneinfo/Asia/Shanghai:ro
+      - ./data/caddy/:/data/
+      - ./www/:/var/www/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,17 @@
+# docker compose example
 services:
   caddy:
+    pull_policy: always
     image: public.ecr.aws/sliamb/caddy:latest
     container_name: caddy
     restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
     environment:
       - TZ=Asia/Shanghai
+      - DNS=223.5.5.5,8.8.8.8
     volumes:
-      - /usr/share/zoneinfo/Asia/Shanghai:/usr/share/zoneinfo/Asia/Shanghai:ro
-      - ./data/caddy/:/data/
-      - ./www/:/var/www/
+      - /share/Container/caddy/data:/data
+    network_mode: "host"
+    # Use mapping if not using host network_mode.
+    # ports:
+    #   - "80:80"
+    #   - "443:443"

--- a/init.sh
+++ b/init.sh
@@ -9,4 +9,4 @@ else
 fi
 ls -shan /data
 sed 's/\r$//' /data/caddyfile.txt >/tmp/caddyfile
-caddy run --config /tmp/caddyfile --adapter caddyfile
+exec caddy run --config /tmp/caddyfile --adapter caddyfile


### PR DESCRIPTION
1. 调整init.sh。加了个`exec`，让caddy能正确处理docker退出信号，不然每次退出都需要10s强制
2. 添加docker-compose示例。主要是需要映射宿主机`/usr/share/zoneinfo/Asia/Shanghai`时区数据文件、使得`TZ`环境变量生效